### PR TITLE
fix compatibilities rule

### DIFF
--- a/lib/rules/compatibilities.js
+++ b/lib/rules/compatibilities.js
@@ -1,6 +1,5 @@
 module.exports = {
   'compat/compat': [
-    'error',
-    'last 1 version, last 1 firefox version, last 1 edge version, ie 11, not safari < 12'
+    'error'
   ]
 };


### PR DESCRIPTION
It might be some issue with `compatibilities.js` file.

the following rule

`
  'compat/compat': [
    'error',
    'last 1 version, last 1 firefox version, last 1 edge version, ie 11, not safari < 12'
  ]
`

 throws the error during eslint `validateRuleOptions ` process
`
Error: .eslintrc.yml » plugin:@salesforce/aura/recommended:
	Configuration for rule "compat/compat" is invalid:
	Value ["last 1 version, last 1 firefox version, last 1 edge version, ie 11, not safari < 12"] should NOT have more than 0 items.
`

I've removed the second parameter and now it works fine.