### PR TITLE
chore: Remove huky@4 configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,11 +56,5 @@
   "mocha": {
     "recursive": true,
     "reporter": "dot"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "git-precommit-checks && lint-staged"
-    }
   }
 }


### PR DESCRIPTION
After the update to husky@5, the `husky` field in `package.json` is not used anymore.