### PR TITLE
feat: Bump ESLint peer dependency to ESLint 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=5.0.0"
+        "eslint": "^7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "eslint": ">=5.0.0"
+    "eslint": "^7"
   },
   "dependencies": {
     "eslint-plugin-compat": "^3.9.0"


### PR DESCRIPTION
Restrict peer dependency to `eslint@^7`. This prevents unexpected issues if eslint were to release a breaking change.

Fixes #13.